### PR TITLE
Remove unnecessary PIC flag

### DIFF
--- a/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
@@ -136,8 +136,6 @@ set_target_properties(${rosidl_generate_interfaces_TARGET}${_target_suffix} PROP
     99
   C_STANDARD_REQUIRED
     YES
-  POSITION_INDEPENDENT_CODE
-    YES
   )
 
 target_compile_options(${rosidl_generate_interfaces_TARGET}${_target_suffix}


### PR DESCRIPTION
This pull request removes the unnecessary `pic` flag. This flag is outdated due to #14.