### PR TITLE
Support for string sequences

### DIFF
--- a/rosidl_typesupport_microxrcedds_c/resource/msg__type_support_c.c.em
+++ b/rosidl_typesupport_microxrcedds_c/resource/msg__type_support_c.c.em
@@ -219,6 +219,12 @@ static bool _@(message.structure.namespaced_type.name)__cdr_serialize(
         }
       }
     }
+@[      elif isinstance(member.type.value_type, AbstractString)]@
+    const size_t size = ros_message->@(member.name).size;
+    rv = ucdr_serialize_uint32_t(cdr, size);
+    for (size_t i = 0; rv && i < size; ++i) {
+      rv = ucdr_serialize_string(cdr, ros_message->@(member.name).data[i].data);
+    }
 @[      end if]@
 @[    end if]@
   }
@@ -291,6 +297,24 @@ static bool _@(message.structure.namespaced_type.name)__cdr_deserialize(
         )()->data))->cdr_deserialize(cdr, &ros_message->@(member.name).data[i]);
       if(rv == false){
         break;
+      }
+    }
+@[      elif isinstance(member.type.value_type, AbstractString)]@
+    uint32_t size;
+    rv = ucdr_deserialize_uint32_t(cdr, &size);
+
+    if(size > ros_message->@(member.name).capacity){
+      fprintf(stderr, "cannot allocate received sequence in ros_message\n");
+      return 0;
+    }
+    ros_message->@(member.name).size = size;
+
+    for (size_t i = 0; rv && i < size; i++) {
+      size_t capacity = ros_message->@(member.name).data[i].capacity;
+      char * data = ros_message->@(member.name).data[i].data;
+      rv = ucdr_deserialize_string(cdr, data, capacity);
+      if (rv) {
+        ros_message->@(member.name).data[i].size = strlen(data);
       }
     }
 @[      end if]@

--- a/rosidl_typesupport_microxrcedds_cpp/resource/msg__type_support_cpp.cpp.em
+++ b/rosidl_typesupport_microxrcedds_cpp/resource/msg__type_support_cpp.cpp.em
@@ -223,6 +223,27 @@ cdr_deserialize(
     if (rv) {
       ros_message.@(member.name).resize(size);
     }
+@[      elif isinstance(member.type.value_type, AbstractString)]@
+    uint32_t size;
+    rv = ucdr_deserialize_uint32_t(cdr, &size);
+
+    if (size > ros_message.@(member.name).capacity()) {
+      ros_message.@(member.name).resize(size);
+    } else {
+      ros_message.@(member.name).resize(ros_message.@(member.name).capacity());
+    }
+
+    for (size_t i = 0; rv && i < size; i++) {
+      uint32_t capacity = ros_message.@(member.name)[i].capacity();
+      char * temp = static_cast<char *>(malloc(capacity * sizeof(char)));
+      rv = ucdr_deserialize_string(cdr, temp, capacity);
+      if (rv) {
+        std::string stemp(temp);
+        stemp.shrink_to_fit();
+        ros_message.@(member.name)[i] = std::move(stemp);
+      }
+      free(temp);
+    }
 @[      end if]@
 @[    end if]@
   }

--- a/rosidl_typesupport_microxrcedds_cpp/resource/msg__type_support_cpp.cpp.em
+++ b/rosidl_typesupport_microxrcedds_cpp/resource/msg__type_support_cpp.cpp.em
@@ -149,6 +149,12 @@ cdr_serialize(
 @[        else]@
     rv = ucdr_serialize_sequence_@(get_suffix(member.type.value_type.typename))(cdr, &ros_message.@(member.name)[0], size);
 @[        end if]@
+@[      elif isinstance(member.type.value_type, AbstractString)]@
+    size_t size = ros_message.@(member.name).size();
+    rv = ucdr_serialize_uint32_t(cdr, size);
+    for (size_t i = 0; rv && i < size; ++i) {
+      rv = ucdr_serialize_string(cdr, ros_message.@(member.name)[i].c_str());
+    }
 @[      end if]@
 @[    end if]@
   }

--- a/test/cpp/src/test_typesupport.cpp
+++ b/test/cpp/src/test_typesupport.cpp
@@ -24,6 +24,7 @@
 
 // Specific defined types used during testing
 #include "rosidl_typesupport_microxrcedds_test_msg/msg/primitive.hpp"
+#include "rosidl_typesupport_microxrcedds_test_msg/msg/sequence.hpp"
 
 /*
  * @brief TestTypeSupport class, used to automate typesupport testing for a specific type.
@@ -90,6 +91,10 @@ public:
     ucdrBuffer mb_writer;
     ucdrBuffer mb_reader;
 
+    /*
+     * TODO(jamoralp): improve this buffer's creation in terms of size.
+     * Maybe we can use CDR max serialized size here, also to check that this method works properly.
+     */
     uint8_t mb_buffer[5000];
     ucdr_init_buffer(&mb_writer, mb_buffer, sizeof(mb_buffer));
     ucdr_init_buffer(&mb_reader, mb_buffer, sizeof(mb_buffer));
@@ -182,6 +187,41 @@ TYPED_TEST(PrimitivesTestTypeSupport, serialize_primitive_types)
   init_primitive.nested_test.unbounded_string4 = "TYZ0123456789";
 
   this->setup(std::move(init_primitive), compare_primitives);
+  this->check_identifier();
+  this->test_serialize_deserialize();
+}
+
+/*
+ * @brief Sequence ROS 2 types serialization and deserialization tests.
+ */
+template <typename T>
+class SequencesTestTypeSupport : public TestTypeSupport<T> {};
+
+TYPED_TEST_CASE(SequencesTestTypeSupport,
+  testing::Types<rosidl_typesupport_microxrcedds_test_msg::msg::Sequence>);
+TYPED_TEST(SequencesTestTypeSupport, serialize_sequence_types)
+{
+  std::function<void (
+      const rosidl_typesupport_microxrcedds_test_msg::msg::Sequence &,
+      const rosidl_typesupport_microxrcedds_test_msg::msg::Sequence &)> compare_sequences ([](
+          const rosidl_typesupport_microxrcedds_test_msg::msg::Sequence & A,
+          const rosidl_typesupport_microxrcedds_test_msg::msg::Sequence & B) -> void
+  {
+    EXPECT_EQ(A.sequence_string_test.size(), B.sequence_string_test.size());
+
+    for (size_t i = 0; i < A.sequence_string_test.size(); ++i)
+    {
+      EXPECT_EQ(A.sequence_string_test[i].compare(B.sequence_string_test[i]), 0);
+    }
+  });
+
+  rosidl_typesupport_microxrcedds_test_msg::msg::Sequence init_sequence;
+  init_sequence.sequence_string_test.emplace_back("This");
+  init_sequence.sequence_string_test.emplace_back("is");
+  init_sequence.sequence_string_test.emplace_back("a");
+  init_sequence.sequence_string_test.emplace_back("test");
+
+  this->setup(std::move(init_sequence), compare_sequences);
   this->check_identifier();
   this->test_serialize_deserialize();
 }

--- a/test/msg/CMakeLists.txt
+++ b/test/msg/CMakeLists.txt
@@ -19,13 +19,14 @@ project(rosidl_typesupport_microxrcedds_test_msg)
 find_package(ament_cmake REQUIRED)
 
 if(BUILD_TESTING)
-  
+
   find_package(builtin_interfaces REQUIRED)
   find_package(rosidl_default_generators REQUIRED)
 
   set(msg_files
     "msg/UnboundedString.msg"
     "msg/Primitive.msg"
+    "msg/Sequence.msg"
     )
 
   rosidl_generate_interfaces(${PROJECT_NAME}

--- a/test/msg/msg/Sequence.msg
+++ b/test/msg/msg/Sequence.msg
@@ -1,0 +1,1 @@
+string[] sequence_string_test


### PR DESCRIPTION
This PR adds the following features:
* Support for string sequences.

Workflow:
- [x] Upload regression tests. [PR #22](https://github.com/micro-ROS/rosidl_typesupport_microxrcedds/pull/22) is required first.
- [x] Give support for string sequences. Test must be marked as `passed` before merging.