### PR TITLE
Use FindPython3 explicitly instead of FindPythonInterp implicitly

### DIFF
--- a/rosidl_typesupport_microxrcedds_c/CMakeLists.txt
+++ b/rosidl_typesupport_microxrcedds_c/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(rosidl_typesupport_microxrcedds_c LANGUAGES C)
 

--- a/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
@@ -72,12 +72,16 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
   )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 # Execute python script
 add_custom_command(
   OUTPUT
     ${_generated_files}
   COMMAND
-    ${PYTHON_EXECUTABLE} ${rosidl_typesupport_microxrcedds_c_BIN}
+    Python3::Interpreter
+  ARGS
+    ${rosidl_typesupport_microxrcedds_c_BIN}
     --generator-arguments-file "${generator_arguments_file}"
   DEPENDS
     ${target_dependencies}

--- a/rosidl_typesupport_microxrcedds_c/package.xml
+++ b/rosidl_typesupport_microxrcedds_c/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
   <buildtool_export_depend>microcdr</buildtool_export_depend>
+  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_runtime_c</buildtool_export_depend>
 

--- a/rosidl_typesupport_microxrcedds_cpp/CMakeLists.txt
+++ b/rosidl_typesupport_microxrcedds_cpp/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.12)
 
 project(rosidl_typesupport_microxrcedds_cpp LANGUAGES CXX)
 

--- a/rosidl_typesupport_microxrcedds_cpp/cmake/rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_cpp/cmake/rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake
@@ -72,12 +72,16 @@ rosidl_write_generator_arguments(
   TARGET_DEPENDENCIES ${target_dependencies}
   )
 
+find_package(Python3 REQUIRED COMPONENTS Interpreter)
+
 # Execute python script
 add_custom_command(
   OUTPUT
     ${_generated_files}
   COMMAND
-    ${PYTHON_EXECUTABLE} ${rosidl_typesupport_microxrcedds_cpp_BIN}
+    Python3::Interpreter
+  ARGS
+    ${rosidl_typesupport_microxrcedds_cpp_BIN}
     --generator-arguments-file "${generator_arguments_file}"
   DEPENDS
     ${target_dependencies} ${_dds_idl_files}

--- a/rosidl_typesupport_microxrcedds_cpp/package.xml
+++ b/rosidl_typesupport_microxrcedds_cpp/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>rosidl_runtime_cpp</buildtool_depend>
 
   <buildtool_export_depend>ament_cmake_ros</buildtool_export_depend>
+  <buildtool_export_depend>python3</buildtool_export_depend>
   <buildtool_export_depend>rosidl_typesupport_microxrcedds_c</buildtool_export_depend>
   <buildtool_export_depend>rosidl_cmake</buildtool_export_depend>
   <buildtool_export_depend>rosidl_runtime_cpp</buildtool_export_depend>


### PR DESCRIPTION
These packages were using `PYTHON_EXECUTABLE`, but weren't `find_package()`ing `FindPythonInterp`. Upstream PRs ros2/rosidl#612 and ament/ament_cmake#355 removed two uses of `PythonInterp`. This PR makes it use `Python3::Interpreter` from `FindPython3` because CMake 3.12 deprecates `FindPythonInterp`.