### PR TITLE
Fix jazzy interfaces

### DIFF
--- a/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
@@ -169,11 +169,15 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
       unset(_dep_tslib_abs)
       find_library(_dep_tslib_abs
         NAMES "${_dep_tslib}" "${_pkg_name}${_target_suffix}"
-        HINTS "${_dep_prefix}/lib" "${_dep_prefix}/lib64"
+        HINTS "${_dep_prefix}"
+        PATH_SUFFIXES lib lib64 "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
         NO_DEFAULT_PATH
       )
       if(_dep_tslib_abs)
         list(APPEND _dep_tslibs "${_dep_tslib_abs}")
+      else()
+        # Preserve previous behavior if resolution fails (e.g. plain link name or CMake target)
+        list(APPEND _dep_tslibs "${_dep_tslib}")
       endif()
     endif()
   endforeach()

--- a/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_c/cmake/rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
@@ -159,9 +159,41 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name}
     )
-  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    ${${_pkg_name}_LIBRARIES${_target_suffix}}
+  set(_dep_tslibs "")
+  get_filename_component(_dep_prefix "${${_pkg_name}_DIR}/../../.." ABSOLUTE)
+  foreach(_dep_tslib ${${_pkg_name}_LIBRARIES${_target_suffix}})
+    if(IS_ABSOLUTE "${_dep_tslib}" AND EXISTS "${_dep_tslib}")
+      list(APPEND _dep_tslibs "${_dep_tslib}")
+    else()
+      unset(_dep_tslib_abs CACHE)
+      unset(_dep_tslib_abs)
+      find_library(_dep_tslib_abs
+        NAMES "${_dep_tslib}" "${_pkg_name}${_target_suffix}"
+        HINTS "${_dep_prefix}/lib" "${_dep_prefix}/lib64"
+        NO_DEFAULT_PATH
+      )
+      if(_dep_tslib_abs)
+        list(APPEND _dep_tslibs "${_dep_tslib_abs}")
+      endif()
+    endif()
+  endforeach()
+  if(NOT _dep_tslibs)
+    unset(_dep_tslib_abs CACHE)
+    unset(_dep_tslib_abs)
+    find_library(_dep_tslib_abs
+      NAMES "${_pkg_name}${_target_suffix}"
+      HINTS "${_dep_prefix}/lib" "${_dep_prefix}/lib64"
+      NO_DEFAULT_PATH
     )
+    if(_dep_tslib_abs)
+      list(APPEND _dep_tslibs "${_dep_tslib_abs}")
+    endif()
+  endif()
+  if(_dep_tslibs)
+    target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+      ${_dep_tslibs}
+      )
+  endif()
 endforeach()
 
 target_link_libraries(

--- a/rosidl_typesupport_microxrcedds_c/resource/srv__rosidl_typesupport_microxrcedds_c.h.em
+++ b/rosidl_typesupport_microxrcedds_c/resource/srv__rosidl_typesupport_microxrcedds_c.h.em
@@ -18,15 +18,6 @@ TEMPLATE(
 }@
 
 @{
-TEMPLATE(
-    'msg__rosidl_typesupport_microxrcedds_c.h.em',
-    package_name=package_name,
-    interface_path=interface_path,
-    message=service.event_message,
-    include_directives=include_directives)
-}@
-
-@{
 header_files = [
     'rosidl_runtime_c/service_type_support_struct.h',
     'rosidl_typesupport_interface/macros.h',

--- a/rosidl_typesupport_microxrcedds_c/resource/srv__type_support_c.c.em
+++ b/rosidl_typesupport_microxrcedds_c/resource/srv__type_support_c.c.em
@@ -4,7 +4,6 @@ from rosidl_generator_c import idl_structure_type_to_c_typename
 from rosidl_generator_type_description import GET_DESCRIPTION_FUNC
 from rosidl_generator_type_description import GET_HASH_FUNC
 from rosidl_generator_type_description import GET_SOURCES_FUNC
-from rosidl_parser.definition import SERVICE_EVENT_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_REQUEST_MESSAGE_SUFFIX
 from rosidl_parser.definition import SERVICE_RESPONSE_MESSAGE_SUFFIX
 
@@ -22,15 +21,6 @@ TEMPLATE(
     package_name=package_name,
     interface_path=interface_path,
     message=service.response_message,
-    include_directives=include_directives)
-}@
-
-@{
-TEMPLATE(
-    'msg__type_support_c.c.em',
-    package_name=package_name,
-    interface_path=interface_path,
-    message=service.event_message,
     include_directives=include_directives)
 }@
 
@@ -78,16 +68,10 @@ static rosidl_service_type_support_t @(service.namespaced_type.name)__handle = {
 
   &_@(service.namespaced_type.name)@(SERVICE_REQUEST_MESSAGE_SUFFIX)__type_support,
   &_@(service.namespaced_type.name)@(SERVICE_RESPONSE_MESSAGE_SUFFIX)__type_support,
-  &_@(service.namespaced_type.name)@(SERVICE_EVENT_MESSAGE_SUFFIX)__type_support,
+  NULL,
 
-  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_CREATE_EVENT_MESSAGE_SYMBOL_NAME(
-    rosidl_typesupport_c,
-    @(',\n    '.join(service.namespaced_type.namespaced_name()))
-  ),
-  ROSIDL_TYPESUPPORT_INTERFACE__SERVICE_DESTROY_EVENT_MESSAGE_SYMBOL_NAME(
-    rosidl_typesupport_c,
-    @(',\n    '.join(service.namespaced_type.namespaced_name()))
-  ),
+  NULL,
+  NULL,
 
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(GET_HASH_FUNC),
   &@(idl_structure_type_to_c_typename(service.namespaced_type))__@(GET_DESCRIPTION_FUNC),

--- a/rosidl_typesupport_microxrcedds_cpp/cmake/rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_cpp/cmake/rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake
@@ -170,11 +170,15 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
       unset(_dep_tslib_abs)
       find_library(_dep_tslib_abs
         NAMES "${_dep_tslib}" "${_pkg_name}${_target_suffix}"
-        HINTS "${_dep_prefix}/lib" "${_dep_prefix}/lib64"
+        HINTS "${_dep_prefix}"
+        PATH_SUFFIXES lib lib64 "lib/${CMAKE_LIBRARY_ARCHITECTURE}"
         NO_DEFAULT_PATH
       )
       if(_dep_tslib_abs)
         list(APPEND _dep_tslibs "${_dep_tslib_abs}")
+      else()
+        # Preserve previous behavior if resolution fails (e.g. plain link name or CMake target)
+        list(APPEND _dep_tslibs "${_dep_tslib}")
       endif()
     endif()
   endforeach()

--- a/rosidl_typesupport_microxrcedds_cpp/cmake/rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake
+++ b/rosidl_typesupport_microxrcedds_cpp/cmake/rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake
@@ -160,9 +160,41 @@ foreach(_pkg_name ${rosidl_generate_interfaces_DEPENDENCY_PACKAGE_NAMES})
   ament_target_dependencies(${rosidl_generate_interfaces_TARGET}${_target_suffix}
     ${_pkg_name}
     )
-  target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
-    ${${_pkg_name}_LIBRARIES${_target_suffix}}
+  set(_dep_tslibs "")
+  get_filename_component(_dep_prefix "${${_pkg_name}_DIR}/../../.." ABSOLUTE)
+  foreach(_dep_tslib ${${_pkg_name}_LIBRARIES${_target_suffix}})
+    if(IS_ABSOLUTE "${_dep_tslib}" AND EXISTS "${_dep_tslib}")
+      list(APPEND _dep_tslibs "${_dep_tslib}")
+    else()
+      unset(_dep_tslib_abs CACHE)
+      unset(_dep_tslib_abs)
+      find_library(_dep_tslib_abs
+        NAMES "${_dep_tslib}" "${_pkg_name}${_target_suffix}"
+        HINTS "${_dep_prefix}/lib" "${_dep_prefix}/lib64"
+        NO_DEFAULT_PATH
+      )
+      if(_dep_tslib_abs)
+        list(APPEND _dep_tslibs "${_dep_tslib_abs}")
+      endif()
+    endif()
+  endforeach()
+  if(NOT _dep_tslibs)
+    unset(_dep_tslib_abs CACHE)
+    unset(_dep_tslib_abs)
+    find_library(_dep_tslib_abs
+      NAMES "${_pkg_name}${_target_suffix}"
+      HINTS "${_dep_prefix}/lib" "${_dep_prefix}/lib64"
+      NO_DEFAULT_PATH
     )
+    if(_dep_tslib_abs)
+      list(APPEND _dep_tslibs "${_dep_tslib_abs}")
+    endif()
+  endif()
+  if(_dep_tslibs)
+    target_link_libraries(${rosidl_generate_interfaces_TARGET}${_target_suffix}
+      ${_dep_tslibs}
+      )
+  endif()
 endforeach()
 
 target_link_libraries(


### PR DESCRIPTION
This PR fixes two issues in the Micro XRCE-DDS typesupport generators that show up when building recent ROS 2 interface sets inside a micro-ROS firmware workspace.

First, the generated C and C++ Micro XRCE-DDS typesupport libraries could fail to link against dependency typesupport libraries when those dependencies exported non-absolute library names. The previous logic relied on target_link_libraries() receiving names that CMake could resolve as real linkable artifacts, which is not always true in this workflow. This PR keeps the existing exported values when they are already absolute paths, and otherwise resolves them with a small find_library() fallback using the dependency package prefix.

Second, the C service templates were generating event-related service typesupport hooks. That path pulls in service_msgs/msg/ServiceEventInfo, which is currently outside the supported Micro XRCE-DDS service event flow and causes link failures in micro-ROS builds. This PR disables event-specific hooks in the generated Micro XRCE-DDS C service typesupport and leaves those fields unset.

These changes are intentionally small and focused on making the Micro XRCE-DDS generators robust in micro-ROS workspaces without changing the normal successful path when dependencies are already exported correctly.

**What changed**

Add a safer dependency library resolution fallback in:
- rosidl_typesupport_microxrcedds_c_generate_interfaces.cmake
- rosidl_typesupport_microxrcedds_cpp_generate_interfaces.cmake

Stop generating unsupported service event hooks in:
- srv__type_support_c.c.em
- srv__rosidl_typesupport_microxrcedds_c.h.em

**Why**
This fixes firmware workspace build failures affecting action and service-heavy interface packages such as example_interfaces, test_msgs, and std_srvs.